### PR TITLE
Make benchmark fair

### DIFF
--- a/bench/index.js
+++ b/bench/index.js
@@ -48,6 +48,7 @@ async function run() {
           type: 'commonjs',
         },
         sourceMaps: true,
+        swcrc: false,
       })
     })
     .add('esbuild', () => {
@@ -132,6 +133,7 @@ async function runAsync() {
                 type: 'commonjs',
               },
               sourceMaps: true,
+              swcrc: false,
             })
           }),
         ).then(() => {


### PR DESCRIPTION
swc is designed for multi-threaded environments. swc pays the cost for it (Arc, Mutex, atomic operations, etc...).
So to be fair, both of them should be multi-threaded.
Also, again, to be fair, useless syscalls related to `.swcrc` should be removed.


My benchmark result:
```
@swc/core x 117 ops/sec ±0.25% (74 runs sampled)
esbuild x 69.73 ops/sec ±1.91% (58 runs sampled)
typescript x 19.62 ops/sec ±10.30% (41 runs sampled)
Transform rxjs/AjaxObservable.ts benchmark bench suite: Fastest is @swc/core
@swc/core x 849,791 ops/sec ±0.52% (84 runs sampled)
esbuild x 840,158 ops/sec ±0.57% (84 runs sampled)
Transform rxjs/AjaxObservable.ts benchmark bench suite: Fastest is @swc/core

```

System:
CPU: E3-1275 v2
RAM: 24G


Btw, I will optimize swc further.
