### PR TITLE
fix(register): handle absolute file paths

### DIFF
--- a/packages/register/register.ts
+++ b/packages/register/register.ts
@@ -1,5 +1,5 @@
 import { platform } from 'os'
-import { join } from 'path'
+import { resolve } from 'path'
 
 import { transformSync } from '@swc-node/core'
 import { SourcemapMap, installSourceMapSupport } from '@swc-node/sourcemap-support'
@@ -62,7 +62,10 @@ function compile(
     return ''
   }
   if (options.files && (options.files as string[]).length) {
-    if (PLATFORM === 'win32' && (options.files as string[]).every((file) => filename !== join(process.cwd(), file))) {
+    if (
+      PLATFORM === 'win32' &&
+      (options.files as string[]).every((file) => filename !== resolve(process.cwd(), file))
+    ) {
       return sourcecode
     }
     if (PLATFORM !== 'win32' && (options.files as string[]).every((file) => !filename.endsWith(file))) {


### PR DESCRIPTION
Register on Windows will wrongfully skip compilation of files if `CompilerOptions.files` contains absolute paths. Using `path.resolve` instead  of `path.join` makes the check work for both relative and absolute paths.