### PR TITLE
Remove note about esbuild being faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ Detail: [@swc-node/core](./packages/core)
 
 ### Benchmark
 
-> ⚠️ Notes: `transformSync` API in esbuild has huge overhead. So `swc` is only faster than esbuild in `transformSync` API. In the `transform` API, `esbuild` is about **1 ~ 1.6x faster** than `swc`.
-
 > transform RxJS `AjaxObservable.ts` to ES2015 & CommonJS `JavaScript`. Benchmark code: [bench](./bench/index.js)
 
 **Hardware info**:


### PR DESCRIPTION
Looks like the benchmark results were updated but this note is still in the readme