### PR TITLE
register use keepClassNames: true by default

### DIFF
--- a/packages/register/register.ts
+++ b/packages/register/register.ts
@@ -99,6 +99,7 @@ function compile(
       emitDecoratorMetadata: options.emitDecoratorMetadata ?? false,
       dynamicImport: options.module ? options.module >= ts.ModuleKind.ES2020 : true,
       esModuleInterop: options.esModuleInterop ?? false,
+      keepClassNames: true,
     })
     // in case of map is undefined
     if (map) {


### PR DESCRIPTION
It's very surprising situation, when class names mangles by default.

Example:
I stuck with project, written on **type-graphql** and all types in *schema.graphql* looks like `User1` instead `User`

Maybe better, keepClassNames by default?