### PR TITLE
feat(jest): support jest 27 transformerConfig

### DIFF
--- a/packages/jest/index.ts
+++ b/packages/jest/index.ts
@@ -1,14 +1,34 @@
 import { createHash } from 'crypto'
 
-import { transformJest } from '@swc-node/core'
+import { Options, transformJest } from '@swc-node/core'
 import { Output } from '@swc/core'
 
 const Cache = new Map<string, Output>()
 
+interface JestConfig26 {
+  transform: [match: string, transformerPath: string, options: Options][]
+}
+
+interface JestConfig27 {
+  transformerConfig: Options
+}
+
+function getJestTransformConfig(jestConfig: JestConfig26 | JestConfig27): Options {
+  if ('transformerConfig' in jestConfig) {
+    // jest 27
+    return jestConfig.transformerConfig
+  }
+
+  if ('transform' in jestConfig) {
+    // jest 26
+    return jestConfig.transform.find(([, transformerPath]) => transformerPath === __filename)?.[2] ?? {}
+  }
+
+  return {}
+}
+
 export = {
-  process(src: string, path: string, jestConfig: any) {
-    const [, , transformOptions = {}] =
-      (jestConfig.transform || []).find(([, transformerPath]: [string, string]) => transformerPath === __filename) || []
+  process(src: string, path: string, jestConfig: JestConfig26 | JestConfig27) {
     if (/\.(t|j)sx?$/.test(path)) {
       // sha1 is fast, and we don't care about security here
       const cacheHash = createHash('sha1')
@@ -18,7 +38,7 @@ export = {
       if (Cache.has(cacheKey)) {
         return Cache.get(cacheKey)
       }
-      const output = transformJest(src, path, transformOptions)
+      const output = transformJest(src, path, getJestTransformConfig(jestConfig))
       Cache.set(cacheKey, output)
       return output
     }


### PR DESCRIPTION
fixes: @swc-node/jest ignores the config provided with the transformer when using jest@27

https://github.com/facebook/jest/pull/10926 made a breaking change for upcoming jest@27 that renders the current config retrieval non functional. `jestConfig.transform` will be undefined and `jestConfig.transformerConfig` will hold the configuration instead.

See also new `TransformerOptions` type https://github.com/facebook/jest/blob/a28f14a9dbd4621eb2e848034cdfdfec28ff9866/packages/jest-transform/src/types.ts#L63