### PR TITLE
doc: align repo name urls

### DIFF
--- a/packages/jest/CHANGELOG.md
+++ b/packages/jest/CHANGELOG.md
@@ -3,149 +3,149 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [1.3.3](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@1.3.2...@swc-node/jest@1.3.3) (2021-10-16)
+## [1.3.3](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@1.3.2...@swc-node/jest@1.3.3) (2021-10-16)
 
 **Note:** Version bump only for package @swc-node/jest
 
-## [1.3.2](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@1.3.1...@swc-node/jest@1.3.2) (2021-09-11)
+## [1.3.2](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@1.3.1...@swc-node/jest@1.3.2) (2021-09-11)
 
 **Note:** Version bump only for package @swc-node/jest
 
-## [1.3.1](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@1.3.0...@swc-node/jest@1.3.1) (2021-06-07)
+## [1.3.1](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@1.3.0...@swc-node/jest@1.3.1) (2021-06-07)
 
 **Note:** Version bump only for package @swc-node/jest
 
-# [1.3.0](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@1.2.1...@swc-node/jest@1.3.0) (2021-05-21)
+# [1.3.0](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@1.2.1...@swc-node/jest@1.3.0) (2021-05-21)
 
 ### Features
 
-- **loader:** implement tsconfig compatible loader ([8c1cd85](https://github.com/Brooooooklyn/node-swc/commit/8c1cd858a64a6b6ec6ff23811bafab7dfe30554d))
+- **loader:** implement tsconfig compatible loader ([8c1cd85](https://github.com/Brooooooklyn/swc-node/commit/8c1cd858a64a6b6ec6ff23811bafab7dfe30554d))
 
-## [1.2.1](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@1.2.0...@swc-node/jest@1.2.1) (2021-04-28)
+## [1.2.1](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@1.2.0...@swc-node/jest@1.2.1) (2021-04-28)
 
 **Note:** Version bump only for package @swc-node/jest
 
-# [1.2.0](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@1.1.1...@swc-node/jest@1.2.0) (2021-04-23)
+# [1.2.0](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@1.1.1...@swc-node/jest@1.2.0) (2021-04-23)
 
 ### Features
 
-- **jest:** support jest 27 transformerConfig ([e2a51b2](https://github.com/Brooooooklyn/node-swc/commit/e2a51b2873898dcfc0a1b03a49f48ce70ea70f0a))
+- **jest:** support jest 27 transformerConfig ([e2a51b2](https://github.com/Brooooooklyn/swc-node/commit/e2a51b2873898dcfc0a1b03a49f48ce70ea70f0a))
 
-## [1.1.1](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@1.1.0...@swc-node/jest@1.1.1) (2021-03-04)
+## [1.1.1](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@1.1.0...@swc-node/jest@1.1.1) (2021-03-04)
 
 **Note:** Version bump only for package @swc-node/jest
 
-# [1.1.0](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@1.0.3...@swc-node/jest@1.1.0) (2021-01-25)
+# [1.1.0](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@1.0.3...@swc-node/jest@1.1.0) (2021-01-25)
 
 ### Features
 
-- **jest:** cache transpile result to avoid source code to be compiled mult times ([77cc3d8](https://github.com/Brooooooklyn/node-swc/commit/77cc3d8ea82728b9b486e1b5fd898f82180c3f37))
+- **jest:** cache transpile result to avoid source code to be compiled mult times ([77cc3d8](https://github.com/Brooooooklyn/swc-node/commit/77cc3d8ea82728b9b486e1b5fd898f82180c3f37))
 
-## [1.0.3](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@1.0.2...@swc-node/jest@1.0.3) (2021-01-04)
-
-**Note:** Version bump only for package @swc-node/jest
-
-## [1.0.2](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@1.0.1...@swc-node/jest@1.0.2) (2020-11-18)
+## [1.0.3](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@1.0.2...@swc-node/jest@1.0.3) (2021-01-04)
 
 **Note:** Version bump only for package @swc-node/jest
 
-## [1.0.1](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@1.0.0...@swc-node/jest@1.0.1) (2020-10-21)
+## [1.0.2](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@1.0.1...@swc-node/jest@1.0.2) (2020-11-18)
 
 **Note:** Version bump only for package @swc-node/jest
 
-## [0.3.8](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.3.6...@swc-node/jest@0.3.8) (2020-09-16)
+## [1.0.1](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@1.0.0...@swc-node/jest@1.0.1) (2020-10-21)
 
 **Note:** Version bump only for package @swc-node/jest
 
-## [0.3.7](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.3.6...@swc-node/jest@0.3.7) (2020-09-13)
+## [0.3.8](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.3.6...@swc-node/jest@0.3.8) (2020-09-16)
 
 **Note:** Version bump only for package @swc-node/jest
 
-## [0.3.6](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.3.5...@swc-node/jest@0.3.6) (2020-09-11)
+## [0.3.7](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.3.6...@swc-node/jest@0.3.7) (2020-09-13)
 
 **Note:** Version bump only for package @swc-node/jest
 
-## [0.3.5](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.3.4...@swc-node/jest@0.3.5) (2020-09-09)
+## [0.3.6](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.3.5...@swc-node/jest@0.3.6) (2020-09-11)
 
 **Note:** Version bump only for package @swc-node/jest
 
-## [0.3.4](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.3.3...@swc-node/jest@0.3.4) (2020-09-07)
+## [0.3.5](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.3.4...@swc-node/jest@0.3.5) (2020-09-09)
 
 **Note:** Version bump only for package @swc-node/jest
 
-## [0.3.3](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.3.2...@swc-node/jest@0.3.3) (2020-09-06)
+## [0.3.4](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.3.3...@swc-node/jest@0.3.4) (2020-09-07)
 
 **Note:** Version bump only for package @swc-node/jest
 
-## [0.3.2](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.3.1...@swc-node/jest@0.3.2) (2020-09-04)
+## [0.3.3](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.3.2...@swc-node/jest@0.3.3) (2020-09-06)
 
 **Note:** Version bump only for package @swc-node/jest
 
-## [0.3.1](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.3.0...@swc-node/jest@0.3.1) (2020-09-01)
+## [0.3.2](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.3.1...@swc-node/jest@0.3.2) (2020-09-04)
 
 **Note:** Version bump only for package @swc-node/jest
 
-# [0.3.0](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.1.27...@swc-node/jest@0.3.0) (2020-08-31)
+## [0.3.1](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.3.0...@swc-node/jest@0.3.1) (2020-09-01)
+
+**Note:** Version bump only for package @swc-node/jest
+
+# [0.3.0](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.1.27...@swc-node/jest@0.3.0) (2020-08-31)
 
 ### Features
 
-- **core:** provide jest hoist plugin ([f3638f2](https://github.com/Brooooooklyn/node-swc/commit/f3638f2004b9fb323261a301b6fe354255846965))
-- **jest:** provide jest preset config ([7750ef5](https://github.com/Brooooooklyn/node-swc/commit/7750ef5d7cff3977a2b96f4d76810043e5f0988d))
+- **core:** provide jest hoist plugin ([f3638f2](https://github.com/Brooooooklyn/swc-node/commit/f3638f2004b9fb323261a301b6fe354255846965))
+- **jest:** provide jest preset config ([7750ef5](https://github.com/Brooooooklyn/swc-node/commit/7750ef5d7cff3977a2b96f4d76810043e5f0988d))
 
-# [0.2.0](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.1.27...@swc-node/jest@0.2.0) (2020-08-28)
+# [0.2.0](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.1.27...@swc-node/jest@0.2.0) (2020-08-28)
 
 ### Features
 
-- **core:** provide jest hoist plugin ([f3638f2](https://github.com/Brooooooklyn/node-swc/commit/f3638f2004b9fb323261a301b6fe354255846965))
+- **core:** provide jest hoist plugin ([f3638f2](https://github.com/Brooooooklyn/swc-node/commit/f3638f2004b9fb323261a301b6fe354255846965))
 
-## [0.1.27](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.1.26...@swc-node/jest@0.1.27) (2020-08-24)
-
-**Note:** Version bump only for package @swc-node/jest
-
-## [0.1.26](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.1.25...@swc-node/jest@0.1.26) (2020-08-23)
+## [0.1.27](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.1.26...@swc-node/jest@0.1.27) (2020-08-24)
 
 **Note:** Version bump only for package @swc-node/jest
 
-## [0.1.25](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.1.24...@swc-node/jest@0.1.25) (2020-08-23)
+## [0.1.26](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.1.25...@swc-node/jest@0.1.26) (2020-08-23)
 
 **Note:** Version bump only for package @swc-node/jest
 
-## [0.1.24](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.1.23...@swc-node/jest@0.1.24) (2020-08-21)
+## [0.1.25](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.1.24...@swc-node/jest@0.1.25) (2020-08-23)
 
 **Note:** Version bump only for package @swc-node/jest
 
-## [0.1.23](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.1.22...@swc-node/jest@0.1.23) (2020-08-20)
+## [0.1.24](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.1.23...@swc-node/jest@0.1.24) (2020-08-21)
 
 **Note:** Version bump only for package @swc-node/jest
 
-## [0.1.22](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.1.21...@swc-node/jest@0.1.22) (2020-08-20)
+## [0.1.23](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.1.22...@swc-node/jest@0.1.23) (2020-08-20)
 
 **Note:** Version bump only for package @swc-node/jest
 
-## [0.1.20](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.1.19...@swc-node/jest@0.1.20) (2020-08-18)
+## [0.1.22](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.1.21...@swc-node/jest@0.1.22) (2020-08-20)
 
 **Note:** Version bump only for package @swc-node/jest
 
-## [0.1.19](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.1.18...@swc-node/jest@0.1.19) (2020-08-14)
+## [0.1.20](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.1.19...@swc-node/jest@0.1.20) (2020-08-18)
 
 **Note:** Version bump only for package @swc-node/jest
 
-## [0.1.18](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.1.17...@swc-node/jest@0.1.18) (2020-08-13)
+## [0.1.19](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.1.18...@swc-node/jest@0.1.19) (2020-08-14)
 
 **Note:** Version bump only for package @swc-node/jest
 
-## [0.1.17](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.1.16...@swc-node/jest@0.1.17) (2020-08-10)
+## [0.1.18](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.1.17...@swc-node/jest@0.1.18) (2020-08-13)
 
 **Note:** Version bump only for package @swc-node/jest
 
-## [0.1.16](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.1.15...@swc-node/jest@0.1.16) (2020-08-10)
+## [0.1.17](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.1.16...@swc-node/jest@0.1.17) (2020-08-10)
 
 **Note:** Version bump only for package @swc-node/jest
 
-## [0.1.15](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.1.14...@swc-node/jest@0.1.15) (2020-08-09)
+## [0.1.16](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.1.15...@swc-node/jest@0.1.16) (2020-08-10)
 
 **Note:** Version bump only for package @swc-node/jest
 
-## [0.1.14](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/jest@0.1.13...@swc-node/jest@0.1.14) (2020-08-09)
+## [0.1.15](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.1.14...@swc-node/jest@0.1.15) (2020-08-09)
+
+**Note:** Version bump only for package @swc-node/jest
+
+## [0.1.14](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/jest@0.1.13...@swc-node/jest@0.1.14) (2020-08-09)
 
 **Note:** Version bump only for package @swc-node/jest

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -17,10 +17,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Brooooooklyn/node-swc.git"
+    "url": "git+https://github.com/Brooooooklyn/swc-node.git"
   },
   "bugs": {
-    "url": "https://github.com/Brooooooklyn/node-swc/issues"
+    "url": "https://github.com/Brooooooklyn/swc-node/issues"
   },
   "funding": {
     "type": "github",

--- a/packages/sourcemap-support/CHANGELOG.md
+++ b/packages/sourcemap-support/CHANGELOG.md
@@ -3,10 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-## [0.1.9](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/sourcemap-support@0.1.8...@swc-node/sourcemap-support@0.1.9) (2021-10-16)
+## [0.1.9](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/sourcemap-support@0.1.8...@swc-node/sourcemap-support@0.1.9) (2021-10-16)
 
 **Note:** Version bump only for package @swc-node/sourcemap-support
 
-## [0.1.8](https://github.com/Brooooooklyn/node-swc/compare/@swc-node/sourcemap-support@0.1.7...@swc-node/sourcemap-support@0.1.8) (2020-08-31)
+## [0.1.8](https://github.com/Brooooooklyn/swc-node/compare/@swc-node/sourcemap-support@0.1.7...@swc-node/sourcemap-support@0.1.8) (2020-08-31)
 
 **Note:** Version bump only for package @swc-node/sourcemap-support

--- a/packages/sourcemap-support/package.json
+++ b/packages/sourcemap-support/package.json
@@ -15,13 +15,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Brooooooklyn/node-swc.git"
+    "url": "git+https://github.com/Brooooooklyn/swc-node.git"
   },
   "dependencies": {
     "source-map-support": "^0.5.20"
   },
   "bugs": {
-    "url": "https://github.com/Brooooooklyn/node-swc/issues"
+    "url": "https://github.com/Brooooooklyn/swc-node/issues"
   },
   "devDependencies": {
     "@types/source-map-support": "^0.5.4"


### PR DESCRIPTION
Find these urls are inconsistent (thought works with url redirections). Try to align them with the current repo name.

![image](https://user-images.githubusercontent.com/4800338/137580069-3674a76d-889f-4574-85ba-665a3366636f.png)
