### PR TITLE
feat: accept to transpile files with .mjs extension

### DIFF
--- a/packages/jest/index.ts
+++ b/packages/jest/index.ts
@@ -28,7 +28,7 @@ function getJestTransformConfig(jestConfig: JestConfig26 | JestConfig27): Option
 
 export = {
   process(src: string, path: string, jestConfig: JestConfig26 | JestConfig27) {
-    if (/\.(t|j)sx?$/.test(path)) {
+    if (/\.(tsx?|jsx?|mjs)$/.test(path)) {
       const hash = xxh64(src).toString(16)
       const cacheKey = `${path}-${hash}`
       const maybeCachedEntry = Cache.get(cacheKey)


### PR DESCRIPTION
.mjs seems to be the official file extension in node.js for javascript files with es6+ module syntax (instead of commonjs). Allow @swc-node/jest to transpile those. 

e.g. angular with version 13 started to [only ship mjs files](https://github.com/angular/core-builds/blob/master/package.json#L27-L31).