### PR TITLE
feat(register): add ES2023 and ES2024 target support

### DIFF
--- a/packages/register/__test__/ts-compiler-options-to-swc-config.spec.ts
+++ b/packages/register/__test__/ts-compiler-options-to-swc-config.spec.ts
@@ -146,3 +146,32 @@ test('sourceMap without inlineSourceMap keeps external map output', (t) => {
 
   t.is(swcConfig.sourcemap, true)
 })
+
+test('should support ES2023 target', (t) => {
+  const options: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2023,
+  }
+  const filename = 'some-file.ts'
+  const swcConfig = tsCompilerOptionsToSwcConfig(options, filename)
+  t.is(swcConfig.target, 'es2023')
+  t.is(swcConfig.useDefineForClassFields, true)
+})
+
+test('should support ES2024 target', (t) => {
+  const options: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2024,
+  }
+  const filename = 'some-file.ts'
+  const swcConfig = tsCompilerOptionsToSwcConfig(options, filename)
+  t.is(swcConfig.target, 'es2024')
+  t.is(swcConfig.useDefineForClassFields, true)
+})
+
+test('should map ESNext to es2024', (t) => {
+  const options: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ESNext,
+  }
+  const filename = 'some-file.ts'
+  const swcConfig = tsCompilerOptionsToSwcConfig(options, filename)
+  t.is(swcConfig.target, 'es2024')
+})

--- a/packages/register/read-default-tsconfig.ts
+++ b/packages/register/read-default-tsconfig.ts
@@ -105,9 +105,13 @@ function toTsTarget(target: ts.ScriptTarget): Options['target'] {
     case ts.ScriptTarget.ES2021:
       return 'es2021'
     case ts.ScriptTarget.ES2022:
+      return 'es2022'
+    case ts.ScriptTarget.ES2023:
+      return 'es2023'
+    case ts.ScriptTarget.ES2024:
     case ts.ScriptTarget.ESNext:
     case ts.ScriptTarget.Latest:
-      return 'es2022'
+      return 'es2024'
     case ts.ScriptTarget.JSON:
       return 'es5'
   }


### PR DESCRIPTION
## Summary

Adds support for ES2023 and ES2024 targets in `@swc-node/register` to match SWC's capabilities added in swc-project/swc#9700.

## Changes

- Add `ES2023` and `ES2024` case statements in `toTsTarget()` function
- Update `ESNext` and `Latest` to map to `es2024` (previously `es2022`)
- Add test cases for ES2023 and ES2024 targets
- Add test case for ESNext mapping to es2024

## Problem Fixed

Previously, when users specified ES2023 or ES2024 targets in their tsconfig, the function returned `undefined`, causing SWC to silently fall back to ES5. This resulted in incorrect transpilation for code intended for modern ES environments.

Now these targets either:
- Work correctly (if @swc/core 1.8.0+ is installed), or
- Throw a clear error (if older @swc/core is used)

## Backward Compatibility

- ✅ No peer dependency changes required
- ✅ Users with TypeScript < 5.5 unaffected (cannot specify these targets)
- ✅ Follows existing pattern where consumers ensure version compatibility
- ✅ TypeScript 5.5+ and @swc/core 1.8.0+ users get full support

## Test Plan

- [x] Unit tests pass for new targets
- [x] Integration tests pass with no regressions
- [x] Manual testing with ES2023/ES2024 tsconfig

Fixes #904