### PR TITLE
fix(register): breakage when spawning child processes

### DIFF
--- a/packages/register/esm.mts
+++ b/packages/register/esm.mts
@@ -228,8 +228,15 @@ export const resolve: ResolveHook = async (specifier, context, nextResolve) => {
     specifier.startsWith('file:') ? fileURLToPath(specifier) : specifier,
   )
 
-  if (error) {
-    throw new Error(`${error}: ${specifier} cannot be resolved in ${context.parentURL}`)
+ if (error) {
+    debug('oxc-resolver error, falling back to node resolver', specifier, error);
+    try {
+      const res = await nextResolve(specifier);
+      return addShortCircuitSignal(res);
+    }
+    catch (resolveError) {
+      throw new Error(`${error}: ${specifier} cannot be resolved in ${context.parentURL}`);
+    }
   }
 
   // local project file

--- a/packages/register/esm.mts
+++ b/packages/register/esm.mts
@@ -228,7 +228,7 @@ export const resolve: ResolveHook = async (specifier, context, nextResolve) => {
     specifier.startsWith('file:') ? fileURLToPath(specifier) : specifier,
   )
 
- if (error) {
+  if (error) {
     debug('oxc-resolver error, falling back to node resolver', specifier, error);
     try {
       const res = await nextResolve(specifier);


### PR DESCRIPTION
This fixes an issue where the module resolver breaks when child processes are spawned.

> Error: Cannot find module '@swc-node/register/esm-register': @swc-node/register/esm-register cannot be resolved in ...

When the child process tries to import `@swc-node/register/esm-register`, the already-registered resolve hook intercepts it, `oxc-resolver` can't resolve the package specifier, and the hook throws immediately instead of falling back to Node's default resolver (which handles it fine).

This can be easily reproduced by using `node --test` (which spawns a child-process per test file)

```
node --import @swc-node/register/esm-register --test
```