### PR TITLE
fix(register): pass imports with import attributes through to the default loader

### DIFF
--- a/packages/integrate-module/src/index.ts
+++ b/packages/integrate-module/src/index.ts
@@ -1,6 +1,8 @@
 /* eslint import/order: off */
 import assert from 'node:assert'
+import { spawnSync } from 'node:child_process'
 import test from 'node:test'
+import { fileURLToPath } from 'node:url'
 
 import { RepositoryState } from '@napi-rs/simple-git'
 import { bar as subBar } from '@subdirectory/bar.mjs'
@@ -101,4 +103,22 @@ await test('postgres should work', async () => {
 
 await test('resolve conditions', () => {
   assert.equal(name, 'from-dev')
+})
+
+// `with { type: 'text' }` is supported since Node.js 26.5, behind --experimental-import-text
+const [nodeMajor, nodeMinor] = process.versions.node.split('.').map(Number)
+const supportsTextImports = nodeMajor > 26 || (nodeMajor === 26 && nodeMinor >= 5)
+
+await test('text import attributes should pass through to the default loader', { skip: !supportsTextImports }, () => {
+  const { status, stderr } = spawnSync(
+    process.execPath,
+    [
+      '--experimental-import-text',
+      '--import=@swc-node/register/esm-register',
+      fileURLToPath(new URL('./text-import/index.ts', import.meta.url)),
+    ],
+    { env: process.env },
+  )
+
+  assert.equal(status, 0, stderr?.toString())
 })

--- a/packages/integrate-module/src/text-import/data.txt
+++ b/packages/integrate-module/src/text-import/data.txt
@@ -1,0 +1,1 @@
+text import works

--- a/packages/integrate-module/src/text-import/index.ts
+++ b/packages/integrate-module/src/text-import/index.ts
@@ -1,0 +1,5 @@
+import assert from 'node:assert'
+
+import data from './data.txt' with { type: 'text' }
+
+assert.equal(data, 'text import works\n')

--- a/packages/integrate-module/src/text-import/txt.d.ts
+++ b/packages/integrate-module/src/text-import/txt.d.ts
@@ -1,0 +1,4 @@
+declare module '*.txt' {
+  const text: string
+  export default text
+}

--- a/packages/register/esm.mts
+++ b/packages/register/esm.mts
@@ -305,6 +305,13 @@ export const load: LoadHook = async (url, context, nextLoad) => {
     return nextLoad(url, context)
   }
 
+  // import attributes are handled by the default loader,
+  // e.g. `with { type: 'text' }` since Node.js 26.5 (behind --experimental-import-text)
+  if (context.importAttributes?.type) {
+    debug('skip load: import attributes', url)
+    return nextLoad(url, context)
+  }
+
   const { source, format: resolvedFormat } = await nextLoad(url, context)
 
   if (!source) {


### PR DESCRIPTION
### Problem

Node.js 26.5.0 introduced text imports (`import sql from './query.sql' with { type: 'text' }`, behind `--experimental-import-text`, nodejs/node#62300). With `@swc-node/register/esm` registered, these imports crash:

```
Exception during run: [Error:   x Expression expected
   ,-[/app/src/queries/query.sql:2:1]
 1 | SELECT ...
   :                     ^
Caused by:
    Syntax Error] { code: 'GenericFailure' }
```

The `resolve` hook already defers to `nextResolve` when import attributes are present, but the `load` hook does not: it takes the source returned by `nextLoad` and compiles it with swc as TypeScript, so the raw text content is fed to the parser.

### Fix

Skip the `load` hook when `context.importAttributes.type` is set, mirroring the existing behaviour of the `resolve` hook. The default loader then handles the module (`json` was already covered by the `context.format` check above; this also covers `text` and any future attribute-driven formats).

### Test

Added an `integrate-module` test that spawns a child Node process with `--experimental-import-text --import=@swc-node/register/esm-register` and imports a `.txt` file `with { type: 'text' }` from a `.ts` entry. Skipped on Node < 26.5 (the current CI matrix of 22/24 skips it; it runs and passes on 26.5.0, and fails without the fix).

```
✔ text import attributes should pass through to the default loader (306.208667ms)
ℹ tests 23
ℹ pass 23
ℹ fail 0
```
