### PR TITLE
Update peer dep on `typescript`

### DIFF
--- a/packages/register/package.json
+++ b/packages/register/package.json
@@ -50,7 +50,7 @@
   },
   "peerDependencies": {
     "@swc/core": ">= 1.4.13",
-    "typescript": ">= 4.3"
+    "typescript": ">= 4.3 < 7"
   },
   "devDependencies": {
     "@swc/core": "^1.13.3",


### PR DESCRIPTION
Currently, `@swc-node/register` is incompatible with the recently-released `typescript@7` because its export structure has changed. As a temporary fix, updating the `peerDependencies` linkage to reflect this should help avoid surprises. (See https://github.com/swc-project/swc-node/issues/1049.)