### PR TITLE
fix(register): always inline source maps in auto mode so debuggers work

### DIFF
--- a/packages/register/__test__/register-runtime-tuning.spec.ts
+++ b/packages/register/__test__/register-runtime-tuning.spec.ts
@@ -124,6 +124,37 @@ test.serial('supports sourcemap store-only mode to avoid inline map payload', (t
   t.true(SourcemapMap.has(filename))
 })
 
+test.serial('auto source map mode inlines the map so debuggers can bind breakpoints', (t) => {
+  // Regression guard for https://github.com/swc-project/swc-node/issues/1059.
+  // In auto mode (no SWC_NODE_SOURCE_MAP_MODE) the emitted code must carry an
+  // inline sourceMappingURL even when process.sourceMapsEnabled is false. The V8
+  // inspector reads that inline map to bind breakpoints, and it does so
+  // regardless of --enable-source-maps. Dropping the inline map here is what
+  // broke the debugger in 1.12.0.
+  delete process.env.SWC_NODE_SOURCE_MAP_MODE
+
+  const previousSourceMaps = process.sourceMapsEnabled
+  process.setSourceMapsEnabled(false)
+  t.teardown(() => process.setSourceMapsEnabled(previousSourceMaps))
+
+  sinon.stub(swcCore, 'transformSync').returns({
+    code: 'console.log("auto-inline")',
+    map: emptyMap,
+  })
+
+  const filename = uniquePath('sourcemap-auto', 'ts')
+  const output = compile('const x = 1', filename, {
+    module: ts.ModuleKind.CommonJS,
+    sourceMap: true,
+  })
+
+  // Inline map present -> the inspector can map breakpoints back to source.
+  t.true(output.includes('sourceMappingURL'))
+  // Stored map present -> sourcemap-support keeps Error.stack correct when native
+  // source maps are off.
+  t.true(SourcemapMap.has(filename))
+})
+
 test.serial('skips transform for plain js in commonjs mode', (t) => {
   const transformSyncStub = sinon.stub(swcCore, 'transformSync')
 

--- a/packages/register/read-default-tsconfig.ts
+++ b/packages/register/read-default-tsconfig.ts
@@ -28,9 +28,17 @@ export function getSourceMapMode(): { inline: boolean; store: boolean } {
       return { inline: false, store: false }
   }
 
-  // In auto mode, follow runtime capability: native source maps favor inline,
-  // non-native stacks favor store mode.
-  return process.sourceMapsEnabled ? { inline: true, store: false } : { inline: false, store: true }
+  // In auto mode, always inline the map: the V8 inspector reads the inline
+  // sourceMappingURL off the running code to bind breakpoints, and it does so
+  // regardless of `process.sourceMapsEnabled` (which only governs how Node
+  // rewrites Error.stack). Gating inline emission on that flag broke debuggers
+  // in 1.12.0 (https://github.com/swc-project/swc-node/issues/1059).
+  //
+  // Additionally store the map when native source maps are off so
+  // @swc-node/sourcemap-support keeps Error.stack line numbers correct; when
+  // native maps are on, Node handles stack traces and storing would just retain
+  // a duplicate map.
+  return process.sourceMapsEnabled ? { inline: true, store: false } : { inline: true, store: true }
 }
 
 export function readDefaultTsConfig(


### PR DESCRIPTION
## Problem

Fixes #1059 — after upgrading to `@swc-node/register` **1.12.0**, the Node debugger stopped binding breakpoints (or landed on the wrong line). Downgrading to 1.11.1 fixed it.

## Root cause

The auto source-map mode added in 1.12.0 decides whether to inline the map based on `process.sourceMapsEnabled`:

```
getSourceMapMode() "auto":
  process.sourceMapsEnabled ? { inline: true,  store: false }   // needs --enable-source-maps
                            : { inline: false, store: true }    // DEFAULT — no inline map
```

`process.sourceMapsEnabled` is **`false` by default** (only true with `--enable-source-maps`). Debuggers — VS Code, `node --inspect` — normally run *without* that flag, so auto mode picks **store-only**: it populates `SourcemapMap` for `@swc-node/sourcemap-support` to rewrite `Error.stack`, but emits **no inline `//# sourceMappingURL=`**.

The V8 inspector reads the inline map off the running code to bind breakpoints, and it does so **regardless** of `--enable-source-maps` (that flag only governs how Node rewrites `Error.stack`). With no inline map, breakpoints have nothing to bind to.

In **1.11.1** the inline map was emitted unconditionally, so the debugger always worked.

## Fix

Auto mode now **always inlines** the map, and additionally **stores** it only when native source maps are off (so `Error.stack` stays correct via `@swc-node/sourcemap-support`, without retaining a duplicate map when Node already handles stack traces):

```diff
-return process.sourceMapsEnabled ? { inline: true, store: false } : { inline: false, store: true }
+return process.sourceMapsEnabled ? { inline: true, store: false } : { inline: true,  store: true }
```

This restores the 1.11.1 behavior of always emitting an inline map. The explicit `inline` / `store` / `none` env modes (`SWC_NODE_SOURCE_MAP_MODE`) are unchanged.

## Verification

- New regression test in `register-runtime-tuning.spec.ts` forces `process.setSourceMapsEnabled(false)` (the debugger-breaking condition) and asserts the emitted code carries an inline map **and** stores it. It fails on the old code, passes on the fix.
- Existing sourcemap integration test (correct stack-trace line numbers, #848/#861) still passes — `store` remains on when native maps are off.
- End-to-end: with `sourceMap: true` and no `--enable-source-maps`, the emitted code now contains an inline map and a thrown error reports the correct source line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXSDomd3mGu4SL4TJ9q6T2